### PR TITLE
Fix Response#to_hash

### DIFF
--- a/lib/agent_cooper/response.rb
+++ b/lib/agent_cooper/response.rb
@@ -12,7 +12,7 @@ module AgentCooper
     end
 
     def to_hash
-      xml.to_hash
+      Hash.from_xml(body)
     end
 
     def code


### PR DESCRIPTION
Fix Response#to_hash, Nokogiri::XML::Document#to_hash doesn't seem to work anymore
